### PR TITLE
fix: replaced ifdef with if when checking FREERTOS_ENABLE

### DIFF
--- a/sources/fx_utils/cy_fault_handlers.c
+++ b/sources/fx_utils/cy_fault_handlers.c
@@ -25,7 +25,7 @@
 *******************************************************************************/
 
 #include "cy_syslib.h"
-#ifdef FREERTOS_ENABLE
+#if FREERTOS_ENABLE
 #include "FreeRTOS.h"
 #include "task.h"
 #endif /* FREERTOS_ENABLE */
@@ -102,7 +102,7 @@ void bus_fault(void)
 }
 #endif
 
-#ifdef FREERTOS_ENABLE
+#if FREERTOS_ENABLE
 /** Stack Overflow callback function from FreeRTOS **/
 void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName)
 {


### PR DESCRIPTION
If the FREERTOS_ENABLE is set to 0, part of the code in cy_fault_handlers.c is not compiled out. Replaced #ifdef FREERTOS_ENABLE with #if FREERTOS_ENABLE to be coherent with similar code in cy_debug.c.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.